### PR TITLE
Very minor documentation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ outputs its column numbers.
 
 From source:
 
-    $ git clone git@github.com:chrisdone/ghci-ng.git
+    $ git clone https://github.com/chrisdone/ghci-ng.git
     $ cabal install ghci-ng/
 
 This version is not available on Hackage yet.


### PR DESCRIPTION
git clone git@... will not work for most users who don't have privileged ssh keys. I'm sure this won't confuse most uses but I thought I'd be helpful and point the mistake out.